### PR TITLE
Update MTR doc with TopDeck format/MTR and include PT collusion etc rules

### DIFF
--- a/content/mtr/mtr.md
+++ b/content/mtr/mtr.md
@@ -1,15 +1,17 @@
 +++
-date = '2025-03-24T22:53:51Z'
+date = '2025-04-23T19:00:51Z'
 title = 'Magic Tournament Rules Addendum'
+menus = 'main'
+url = 'mtr'
 +++
 
 ## Introduction
 
-The following document acts as an extension to the existing official [Magic Tournament Rules](http://wpn.wizards.com/en/document/magic-gathering-tournament-rules) and the unofficial [TopDeck Competitive REL MTR/IPG Addendum for Commander Events](https://topdeck.gg/mtr-ipg-addendum).
+The following document acts as an extension to the existing official [Magic Tournament Rules](https://blogs.magicjudges.org/rules/mtr/) (MTR) for use in Competitive Rules Enforcement Level commander events (commonly refered to as cEDH) in the UK.
 
-This will address smaller local events through to larger events such as qualifiers & multi day events. By having this document, events throughout the country will be consistent and TOs (Tournament Organisers) will have a central reference point to aid event set-up.
+This will address smaller local events through to larger events such as qualifiers & multi day events. By having this document, events throughout the country will be consistent and TOs (Tournament Organisers) will have a central reference point to aid event set-up. Any deviations from these documents should be kept to a minimum and specifically stated on the event page along with an announcement before round 1 begins to ensure players are aware of any changes.
 
-Please note, the following rules may vary when the event being hosted is a qualifier. Events classified as a qualifier may need to follow an alternative ruleset which will be at the discretion of the organisation hosting the event being qualified for.
+Please note, the following rules may vary when the event being hosted is a qualifier. Events classified as a qualifier may need to follow an alternative ruleset which will be at the discretion of the organisation hosting the event being qualified for. Events which follow different rules should link to the respective rules document on their event pages.
 
 ## Code of Conduct
 
@@ -20,11 +22,146 @@ In addition to rules defined in [MTR - 5.4 - Unsporting Conduct](https://blogs.m
 - “Spite plays”, “kingmaking”, and intentionally losing or "throwing" are examples of unsportsmanlike behaviour and may be subject to penalty or suspension. Check the section below for more details.
 - Players are expected to have a general understanding of how to operate the system(s) that they are using to play in the tournament. This includes, but is not limited to: properly reporting match results, finding their game, or using tournament software. Failure to do so in a timely fashion will result in an infraction. Tournament officials may exercise their discretion in assisting players with solving their technical issues, but are in no way required to do so.
 
+## MTR Amendments
+
+Below are the amendments made to the official [MTR](https://blogs.magicjudges.org/rules/mtr/) to adapt it for cEDH. Each is named to reflect which section of the MTR they modify and link to the original version.
+
+### Tournament Mechanics
+
+#### 2.1 Match Structure
+
+[Original](https://blogs.magicjudges.org/rules/mtr2-1/)
+
+In Multiplayer Tournaments, the usual number of Games required to win a Match is one. If a Game ends in a Draw, a new Game is started including every Player in the Pod.
+
+The winner of a Match is the Player that won the required number of Games, or the Player that has won the most Games.
+
+In the case of a tie, the Match is a Draw between the Players that participated in that Match, with the exception of Players that received Match Loss penalties or Players that conceded the Match.
+
+#### 2.2 Play/Draw Rule
+
+[Original](https://blogs.magicjudges.org/rules/mtr2-2/)
+
+Players are seated in a predetermined order established by the [pairing software](#event-software) with Seat One as the starting player.
+
+#### 2.3 Pregame Procedure
+
+[Original](https://blogs.magicjudges.org/rules/mtr2-3/)
+
+Commanders are revealed prior to shuffling and presenting decks. A game should not start until all players are present or 5 minutes have elapsed in the round. Players are not allowed to change commanders between rounds and must use the commander(s) that they submitted with their decklist.
+
+#### 2.4 End-of-Match Procedure
+
+[Original](https://blogs.magicjudges.org/rules/mtr2-4/)
+
+When time is called, the active player finishes their turn, and there are no additional turns. The game ends when the active player passes their turn. If a non-active player is acting in the end step of the active turn, when time is called, the subsequent turn becomes the final one. A time limit of 20 minutes should be applied to the final turn when time is called.
+
+In single-elimination rounds, matches may not end in a draw. If a single-elimination match would end in a draw, for example due to the time limit for the round being reached, then the player who was seeded highest at the end of Swiss will be the winner.
+
+Optionally a Tournament Organiser can opt to have a match end with additional turns. In this case the number of additional turns should be equal to the number of players who haven't been eliminated from the game. If this is chosen then it should be clearly communicated to players both on the event announcement page and as part of the players meeting at the start of the event.
+
+#### 2.5 Conceding or Intentionally Drawing Games or Matches
+
+[Original](https://blogs.magicjudges.org/rules/mtr2-5/)
+
+During a multiplayer game, players are encouraged to concede while they have priority, and the stack is empty on their own turn. A player who needs to concede at any other time will be dropped from the event and must talk to a tournament organizer in order to re-enter. In this case, a judge will facilitate any mandatory detrimental triggers of the conceded player until the stack is empty, any non-detrimental triggers will be missed. In the event this happens in response to combat, the turn will be facilitated until the end of combat, with the conceded player declaring no blockers to any creatures that are attacking them.
+
+### Tournament Rules
+
+#### 3.1 Tiebreakers
+
+[Original](https://blogs.magicjudges.org/rules/mtr3-1/)
+
+Any player receiving a bye will have 3 opponents added to their opponent history with a 0.2 win rate percentage.
+
+#### 3.13 Hidden Information
+
+[Original](https://blogs.magicjudges.org/rules/mtr3-13/)
+
+If a player accidentally gains information about another players hand, such as through that player not sufficiently hiding their hand from the player next to them, then they are free to communicate that information to the other players should they wish to.
+
+### Communication
+
+#### 4.1 Player Communication
+
+[Original](https://blogs.magicjudges.org/rules/mtr4-1/)
+
+The active player may request the table to stop excessively influencing game actions to progress play. This covers situations where a player is attempting to perform a game action and other players are trying to influence the action to their benefit, e.g. attempting to convince a player to target another player's creature with their Swords to Plowshares etc.Failure to do so may result in an Unsporting Conduct - Minor penalty.
+
+If players are talking excessively while holding priority then this should be treated as Slow Play or potentially Stalling.
+
+### Tournament Violations
+
+#### 5.4 Unsporting Conduct
+
+[Original](https://blogs.magicjudges.org/rules/mtr5-4/)
+
+**Coercion**: *Coercing a Player into performing an action over threat of losing the Game to another Player.*
+
+Coercion can happen in non-verbal ways too. It’s not Coercion if actions are discussed within a timing where the affect Player is not yet under pressure to perform that action. When proposing intentional draws, Players can discuss the terms and reveal hands, but they can’t attempt to coerce Players that aren’t in accordance.
+
+Coercion Examples:
+
+- Alice is presenting a win, Bob has an answer, but passes priority since they see that Diane has untapped lands, and they believe Charles has an answer. Since Charles passes priority to Diane, it’s not acceptable that Bob asks Diane to: “Tap a land so that I get priority back, otherwise we lose!”.
+- Alice is presenting a win, Bob has an answer, but passes priority since they see that Diane has untapped lands, and they believe Charles has an answer. Since Charles passes priority to Diane, it’s not acceptable that Bob reveals the answer from their hand at this point with the expectation that Diane taps a land in order for Bob to get the priority back.
+- Alice is presenting a win, Bob has an answer, but notices that Diane has a Thrasios, Triton Hero, and available mana to activate it. It is acceptable that before passing priority, Bob reminds Diane that they can Draw a card to find an answer.
+- Alice is presenting a win, Bob has a win next turn and this is known information. It’s not acceptable that Charles attempts to coerce a Player into intentionally drawing: “If you don’t want to Draw, then I will cast Silence and you lose to Bob” or “You have to accept the Draw, or else we will kill you and we Draw anyway”.
+- Alice is presenting a win, Bob has a win next turn and this is known information. It is acceptable that Charles attempts to politely reason with the Players, without threatening to hand over the win to Bob: Alice, I have this Silence. Do you want to Draw? No? Ok.” - “What about you, Bob and Diane? Are you ok with making a deal to kill Alice and Draw afterwards? It would be better if Alice accepted the Draw, since Bob can break the deal and we might end up losing the Game instead of everyone drawing”.
+
+**Collusion**: *Colluding with an Opponent in order to benefit them in the Tournament.*
+
+Collusion typically occurs when a Player intentionally takes an action that is detrimental to themselves in order to benefit an Opponent. It’s not Collusion if the action is a result of a unintentional strategical error.
+
+Collusion Examples:
+
+- Alice is presenting a win, Bob has an answer and uses it. Charlie uses their answer to stop Bob’s, in order to ensure Alice wins the Match. The Judge’s investigation determines that Charlie is friends with Alice and wants Alice to move to the single elimination portion of the Tournament, and that’s why they used their answer. Charlie is Colluding with Alice and vice-versa.
+- Alice is presenting a win, Daniel has an answer and uses it. Charlie uses their answer to stop Daniel’s, in order to ensure Alice wins the Match. The Judge’s investigation determines that Charlie is friends with Bob and wants Alice to be penalized by collusion in order to give Bob the chance to try and win against Daniel, and that’s why they used their answer. Charlie is Colluding with Bob and vice-versa.
+- Alice is presenting a win, Bob has a win on their next turn and Charlie has an answer to stop Alice and allow Bob to win the Game. In this situation Charlie could conceivably be colluding with Alice or Bob by either not performing an action or by performing an action. However it is also possible that no Collusion is happening. It will be up to the Judge’s investigation to determine if there is Collusion or not.
+
+**Spite Play**: *Performing a detrimental action with the sole purpose of penalizing an Opponent out of Spite.*
+
+It’s not Spite Play if the action is a result of a unintentional strategical error.
+
+Spite Play Examples:
+
+- Alice is presenting a win that makes use of Bob’s existing permanents in order to function. Bob feels disgruntled with Alice’s previous interactions in the Game and scoops up their cards, conceding, in order to prevent Alice from winning the Game. Bob is performing a Spite Play against Alice.
+- Alice is presenting a win that makes use of Bob’s existing permanents in order to function. Bob activates their Necropotence enough times so that they lose the Game. Bob hopes that the Game ends in a Draw, and as such this is not a Spite Play.
+
+In Multiplayer Tournaments, sometimes it will surface the idea that a Player is “Kingmaking” another Player. This notion of Kingmaking is only problematic if it falls under the category of Collusion or Spite Play. Otherwise, it can be a simple unintentional strategical error, and that’s not regulated by Judges.
+
+When investigating these matters, Judges need to take special attention to not reveal strategic information to Players at the table. An Opponent can potentially accuse a Player of Spite Play or Collusion in order to extract strategically relevant information from the Judge’s ruling, for example:
+
+- Player A calls a judge because Player B is casting a Pact of Negation, targetting one of their spells, while Player B only seemingly has 3 available mana in their next upkeep. A Judge comes over, sees this and asks to see Player B’s hand, noticing a Dark Ritual, then dismissing the Spite Play / Collusion claim. Player A, C and D noticed this interaction and now think that Player B must have an instant that can provide mana or a way to win at instant speed in their upkeep.
+
+The problem with this situation is that if Player B was actually doing as Spite Play, they must be penalized immediately so that the integrity of the Game is not compromised any further. However, investigating this, will leak some information, so Judges need to be careful to minimize these leaks:
+
+- By asking the Player if they are aware of the Spite play rules in the open, without seeing their hand, they are simply reiterating what the Player already signalled by casting the Pact of Negation in the first place, minimizing the information leak.
+
 ## Tournament Structure
 
-### Swiss Rounds (subject to changes)
+### Match Points
 
-This will be subject to player attendance, but the Tournament Organiser reserves the right to adjust the following to meet venue/time constraints. Adjustments may not be available when hosting qualifiers that adopt rules from other TOs.
+Players earn 5 match points for each match win, 0 points for each match loss, and 1 match point for each match ending in a draw. Players receiving byes are considered to have won the match. All players listed on a Match must agree to an intentional draw in order to report a Match as such.
+
+### Pairing Guidelines
+
+Priority should be given to forming as many pods with 4 players as possible each round. In cases where this isn't possible, pods may consist of a minimum of 3 players to avoid multiple byes. However, no more than one pod of 3 players should be formed per round, ensuring that only 2 or fewer byes are given due to player count each round. For smaller event sizes it may be better to not use byes as the impact of multiple byes on standings could be more detrimental than multiple 3 player pods. Below is a table of the recommended maximum number of byes to allow based on event size.
+
+|Players|Byes|
+|-|-|
+|1-20|0|
+|21-40|1|
+|41+|2|
+
+Based on this if an event has 21 players then there should be 1 bye and 5 pods of 4 players each round. If an event has 22 players then there should be 0 byes, 4 pods of 4 players, and 2 pods of 3 players each round. If an event has 42 players then there should be 2 byes and 10 pods of 4 players.
+
+### Tie Breakers
+
+All player’s tie breakers will be calculated the same regardless if a player received a bye or not. Any player receiving a bye will have 3 opponents added to their opponent history with a .2 win rate percentage. The lower limit for a tie breaker is updated to .2 for all players
+
+### Swiss Rounds
+
+This will be subject to player attendance, but the Tournament Organiser (TO) reserves the right to adjust the following to meet venue/time constraints. Adjustments may not be available when hosting qualifiers that adopt rules from other TOs.
 
 |Players|Minimum Number of Swiss Rounds|Playoff|
 |-|-|-|
@@ -35,6 +172,10 @@ This will be subject to player attendance, but the Tournament Organiser reserves
 |33-64|5|Top 16|
 |65-128|6|Top 16|
 |129-256|7|Top 40|
+
+Each swiss round lasts 80 minutes. When time is called then [End-of-Match procedure](#24-end-of-match-procedure) should be followed. Normally this will mean the active player finishes their turn and has a maximum of 20 minutes to do this.
+
+Optionally the TO may choose to have additional turns when time is called as detailed in [End-of-Match procedure](#24-end-of-match-procedure), this decision is down to the TO but should take into consideration venue opening times etc.
 
 ### Top Cut - Playoffs
 
@@ -56,54 +197,32 @@ Pods for top 10 should be created as such, where players in the first and second
 |A|3|6|7|10|
 |B|4|5|8|9|
 
+There is no time limit in the single elimination portion (except exceeding venue time limit). In the case where players decide to Intentionally Draw a game during the single elimination portion, a 120 minutes round time limit will be enforced, starting from when the round began.
+
+- This is done to place a limit on the number of Intentional Draws that can happen and potentially extend the single elimination portion indefinitely.
+- This means that players are free to Intentionally Draw a game, but by doing so, the next game(s) they play will have to take the clock into consideration.
+- After 120 minutes, pods that had one or more Intentional Draws are only allowed to continue playing as long as there other Pods still playing, that haven’t Intentionally Draw and thus aren’t subjected to the 120 minutes limit.
+- After 120 minutes, if there are no other pods still playing, that haven’t Intentionally Draw, the Match follows the [standard End-of-Match procedure](#24-end-of-match-procedure) for the Tournament.
+
 ### Top 4 - Finals
 
 The Finals seating will be based on the standings the players got during the Swiss portion, with the highest ranked player going first. The Semi final matches don’t affect this.
 
-If for logistical reasons, the single elimination portion must have a time limit, then by the time a match ends and no winner is found, the highest ranked player in the standings during the swiss rounds is considered the winner.
-
-We will be using byes when the number of players is not divisible by 4. A player can only be awarded one bye during the tournament, and it will be awarded to the lowest ranking player in the standings.
-
-- If the Tournament’s Swiss portion is only 3 rounds, then we will be running pods of 3 players instead of awarding byes.
+It is recommended that the finals has no time limit unlike the [Top Cut](#top-cut---playoffs), even after intentional draws. Should a time limit be required, for example due to venue opening times, then TO discretion is advised to choose an appropriate time limit based on their situation.
 
 ## Event Software
 
-cEDH UK recommends the use of the TopDeck software by TopDeck.
+cEDH UK recommends the use of [TopDeck](https://topdeck.gg) or [Spicerack](https://spicerack.gg).
 
-Please head to topdeck.gg and create your account, it takes 1 minute and is free for players. For tournament organisers there is a monthly fee but we have a cEDH UK account that organisers can use.
+For tournament organisers wishing to use TopDeck there is a cEDH UK account that can be used. Spicerack is free to use but is intended to be linked to a store.
 
 Each event page will allow you to submit your decklist and view pairings and standings. There is also a mobile app for players to access the same information.
-
-## Tournament Rules
-
-- We will use the point system defined in the Multiplayer Addendum:
-  - A Win awards 5 points
-  - A Draw awards 1 point (for all players except those choosing to individually concede or incurring harsh penalties - Game Loss, Match Loss, Disqualification)
-  - A Loss awards 0 points
-  - A Bye awards 5 points
-  - Any player receiving a bye will have 3 opponents added to their opponent history with a .25 win rate percentage.
-
-- Each swiss round lasts 90 minutes (active player finishes their turn) or 75 minutes (one extra turn per active player). This decision is down to the TO unless the event is a qualifier influenced by the hosts of the event being qualified for.
-- Seating order will be set automatically, as well as the turn order using TopDeck.
-- There is no time limit in the single elimination portion (except exceeding venue time limit). In the case where players decide to Intentionally Draw a game during the single elimination portion, a 120 minutes round time limit will be enforced.
-
-  - This is done to place a limit on the number of Intentional Draws that can happen and potentially extend the single elimination portion indefinitely.
-  - This means that players are free to Intentionally Draw a game, but by doing so, the next game(s) they play will have to take the clock into consideration.
-  - This 120 minutes time limit includes the round time already spent.
-  - If the time runs out without a winner in the single elimination portion, the highest ranked player in the swiss rounds is considered the winner.
-
-- Apply the official Commander Banlist.
-- Rules on Playtest cards are down to each individual TO or in the event of a qualifier, it will be down to the hosts of the event being qualified for. Check the section below for details.
-- Penalties: Check the link on the Rules Enforcement Level.
-- After each match, players will need to notify the TO of the result or fill in a match slip provided by the organisation.
-- After the winner of the tournament is determined, the remaining standings are defined by the ranking achieved in the Swiss portion of the event.
-- Non-deterministic loops are allowed, check the section below for more details. Judges discretion regarding if the loop is non deterministic based on hands and board states, Rhystic Stydies, resources etc
 
 ## Playtest Cards
 
 There are three different terms to refer to Magic cards that aren’t actual Magic cards. Proxies, Playtest Cards, and Counterfeits.
 
-From the WPN Terms and Conditions:
+From the [WPN Terms and Conditions](https://wpn.wizards.com/en/terms-and-conditions) section 5:
 
     (j) Proxy Cards. Retail Stores may only allow “proxy” cards in your Events as described in the current official Magic Tournament Rules. A proxy card is a card issued by a Judge at an Event to replace a card that has become damaged during the course of play in such Event and may only be used for the duration of that Event.
     (k) Counterfeit Cards. Counterfeit cards are unauthorized reproductions of authentic Wizards cards. Counterfeit cards are strictly prohibited by Wizards. WPN Members who knowingly manufacture, import, use or distribute counterfeit cards (or facilitate the same by a third party) will have their WPN Membership immediately terminated. Wizards reserves all rights in law and at equity to prosecute individuals engaged in the manufacture, importation or distribution of counterfeit cards.
@@ -111,39 +230,19 @@ From the WPN Terms and Conditions:
 
 Counterfeit cards are not allowed, the inclusion of any such cards in your deck will result in immediate disqualification. We do not support the production of illegitimate cards.
 
+Players will often refer to Proxy cards when they mean Playtest cards. This document will assume that unless stated otherwise any mention by players or event staff to Proxy cards refers to Playtest cards.
+
 We understand that most cEDH decks require a significant financial investment, often prohibitive for players. Some cards are so expensive that it makes many players uncomfortable to physically play with their authentic cards. When signing up for events please check each individual page for their playtest rules.
 
 - Players are responsible for making sure their playtest cards are acceptable by the Judge Team, and are expected to check the validity with them.
-- The Judge Team will evaluate the cards using the same principles defined in the MTR - 3.3 - Authorized Cards, with the exception of the following points:
+- The Judge Team will evaluate the cards using the same principles defined in the [MTR - 3.3 - Authorized Cards](https://blogs.magicjudges.org/rules/mtr3-3/), with the exception of the following points:
 
 - Authorized Game Cards must be regulation-sized ~~, genuine Magic cards publicly released by Wizards of the Coast~~.
   - Ignore the strikethrough text
 - ~~Cards that, unaltered, feature gold borders on their front or back, and~~ cards from the “Heroes of the Realm”, Theros block “Challenge Deck” series, silver bordered cards and acorn symbolled cards are not Authorized Game Cards.
   - Ignore the strikethrough text
 
-## Main Rules
-
-### Rules Enforcement Levels
-
-cEDH UK Events are played under Competitive Rules Enforcement Level. You are expected to know the rules when you sit down to play. Judges will be present to enforce rules and answer any questions.  The Judge Team will apply the [Magic Infraction Procedure Guide](http://wpn.wizards.com/en/document/magic-infraction-procedure-guide) with the addendum of the [TopDeck Competitive REL MTR/IPG Addendum for Commander Events](https://topdeck.gg/mtr-ipg-addendum).
-
-In the event a judge does not wish to issue a turn skip or a match loss cEDH UK events will adopt the ‘Skip Priority’ penalty.
-
-The Penalty consists in the player Passing Priority on every action until the end of their next turn.
-
-- The player will still put triggered abilities on the stack, choose targets for them, and resolve them.
-- The player will be able to pay costs (such as when resolving triggers from Remora, Pact of Negation, Mana Vault, Rhystic Study).
-- The player will be allowed to declare blockers.
-- The player will only be allowed to declare mandatory attackers (such as creatures that must attack).
-- The player will not be allowed to play a land.
-- The player will not be allowed to cast a spell by normal means (but they can if they are resolving a triggered ability, like Rebound or Suspend).
-- The player will not be allowed to activate abilities (except mana abilities to pay for costs).
-
-An important highlight is that a Game Loss or Match Loss penalty will always result in the offending player receiving 0 points for the match, ignoring a potential draw result.
-
-Keep in mind that in accordance with the Multiplayer Addendum to the Infraction Procedure Guide, an accumulation of Warnings within the same infraction results in an upgrade to Game Loss.
-
-### Judges
+## Judges
 
 Our Judges are here to help you! If you notice anything that seems shady, odd, or out of place, please call a Judge. If you have any rules questions, please call a Judge. In addition to the directives defined in this document, the Judge team will follow the directives in the following documents, so it is in your interest to get familiar with them:
 
@@ -155,98 +254,22 @@ Throughout the event, Judges will perform deck checks. This process includes ver
 
 Remember that no ruling aside from the Head Judge’s is considered final as soon as it is given. If for whatever reason you wish to get a second opinion, please tell the ruling Judge that you would like to appeal to the Head Judge.
 
-### Non-Deterministic Loops
-
-According to the [MTR - 4.4 Loops](https://blogs.magicjudges.org/rules/mtr4-4/):
-
-```
-“A loop is a form of tournament shortcut that involves detailing a sequence of actions to be repeated and then performing a number of iterations of that sequence. The loop actions must be identical in each iteration and cannot include conditional actions (‘If this, then that’.)”
-```
-
-In an effort to allow more strategies and diversity amongst decks, some non-deterministic loops, such as those associated with shuffling the deck or any other random element, are allowed. If a player is unsure of how their opponent's loop functions, or is unsure if an opponent can perform the loop, please immediately call a Judge.
-
-If a player executing a loop is incapable of concisely communicating the loop to a Judge, they will not be allowed to perform the loop, as that results in Slow Play. The Head Judge is the final authority on what constitutes an allowed non-deterministic loop.
-
-A player wanting to interrupt a non-deterministic loop will need to be able to do so in a non-deterministic way (when a certain condition is met). That will be allowed, and in case of any doubt, call a Judge.
-
-### Collusion, Kingmaking, and Spite Plays
-
-In game theory, a “king maker” is a player who lacks sufficient resources or position to win at a given game, but possesses enough remaining resources to decide which of the remaining viable players will eventually win.
-
-One element of a multiplayer format is that players can take game actions that allow other players to win accidentally.
-
-Judges will not regulate suboptimal gameplay.
-
-If you believe a player is “king making”, colluding with another player, or performing a “Spite Play”, please call a Judge.
-
-These constitute a violation of the code of conduct and will be treated as such. Collusion in particular is a very serious offense.
-
-Players may not use this anti-kingmaking policy to abuse their opponent’s position as a shield to attempt to win, for example:
-
-- Player A has a win attempt, player B has a win attempt that player A knows about and player C only has one answer to stop A or B but not Both. In this situation, player A cannot just try to win and use the argument that if player C uses their answer, it would be king making.
-
-Keep in mind that sometimes a player might seem to be performing a “king making” or “spite play” decision, when in reality that line of play is the one that favours them most in the tournament progression, for example:
-
-- During Swiss rounds, player A presents a win, player B has a Pact of Negation with no mana to pay for the trigger on their next upkeep. However player B believes that by stopping player A they might have a chance that the game ends in a draw therefore resulting in them gaining 1 point instead of 0.
-- Player A presents a win, and they have Force of Will that player B saw in a previous turn via Gitaxian Probe, player B has a Pact of Negation, with no way to pay for the trigger in the next upkeep, but player B suspects that player C has interaction. Because player B is the first to respond, they must play the Pact of Negation so that player A uses their Force of Will and then allows player C to effectively counter the win.
-
-### Intentionally Drawing Games
-
-While it is completely acceptable that players decide to Intentionally Draw a game, and in some situations, it can be an elegant solution to an apparently “King-making” situation, there are some implications, when it comes to tournament logistics and player conduct:
-
-- In Single Elimination Rounds, given the preference for unlimited time, it’s possible that multiple games end in an Intentional Draw. In order to prevent extending the tournament indefinitely, after the first Intentionally Drawn game, there will be a time limit put in place. This time limit will also include the time already spent on the game. Check the section above for details.
-- In Swiss Rounds, players can opt to Intentionally Draw individual games or the whole match. If players opt to Intentionally Draw a game, they can (and are encouraged) start another game, as long as there is still time left in the round.
-- In any situation, a player cannot be coerced into Intentionally Drawing a game. This means that you can propose an Intentional Draw, but you can’t forcefully impose it on an opponent.
-- Sometimes players can make deals to “kill” a player that doesn’t agree to an Intentional Draw, so that the remaining players can then agree to Intentionally Draw the game. Keep in mind that judges will not enforce upholding such deals, same as with any other deals.
-
-Here are some examples regarding coercion:
-
-- Player A is presenting a win, player B has a win next turn and this is known information. It’s not acceptable that player C attempts to “blackmail” a player: “If you don’t want to draw, then I will cast Silence and you lose to player B” or “You have to accept the draw, or else we will kill you and we draw anyway”.
-- Player A is presenting a win, player B has a win next turn and this is known information. It is acceptable that player C attempts to politely reason with the players: “Player A, I have this Silence. Do you want to draw? No? Ok, but please consider that if we make a deal to kill you it’s way riskier since B can break the deal and we end up losing the game instead of everyone drawing”.
-
-Attempting to coerce a player into accepting an Intentional Draw constitutes a violation of the code of conduct and will be treated as such.
-
-### Mana/Priority Bullying
-
-While it is completely acceptable that players “sandbag” their answers and pass priority, it is not acceptable that players ask other players to perform an action so they can receive priority back.
-
-If during one of your games a player passes priority and then asks you to perform an action so they can get priority back, call a Judge.
-
-Asking a player to perform an action in order to receive priority back constitutes a violation of the code of conduct and will be treated as such.
-
-### Slow Play/Stalling
-
-Given the lengthy nature of the format, and the time limit, it is very important that we all fight to combat slow play and ultimately reduce the chance for stalling abuse. Because of this, we want to encourage all players to actively call a Judge if you feel that an opponent is taking more than a reasonable amount of time making a decision. The Judge team can only give you extra time if you call them during the round!
-
-### Conceding
-
-Some cards, strategies, or lines of play, such as those associated with Najeela or Tivit are reliant on the multiplayer aspect of commander. To facilitate these, players must concede on their turn with an empty stack. This gives all players the opportunity to play to their deck’s strategies. The following exceptions apply to this rule:
-
-- If a player is uncomfortable in a match and would like to discontinue a match as a result, please immediately call a Judge.
-- If a player must leave due to an emergency, please immediately call a Judge.
-
-As per the [MAMTR - 2.5](https://topdeck.gg/mtr-ipg-addendum). During a multiplayer game players are encouraged to concede while they have priority and the stack is empty on their own turn. A player who needs to concede at any other time will be dropped from the event and must talk to the tournament organiser in order to re-enter. In this case a judge will facilitate any mandatory actions of the conceded player until the stack is empty. In the event this happens in response to combat the turn will be facilitated until the end of combat. - If a player conceding at “instant speed” would affect the outcome of the match, the player and all permanents controlled by them beforehand are considered to still exist until the end of the current phase.
-
-### Table Talk
-
-We understand that discussion between players, planning, and strategy is an integral part of commander play.
-
-The penalty “Outside Assistance” will only apply in either of the following scenarios:
-
-- When players in a match asks for or refers to information from a person or medium outside the current match other than a Judge.
-- When a player not involved in the current match, spectator, or any other person offers or otherwise communicates information to a player engaged in a match.
-
-- As per the Outside Assistance Section - players that are eliminated during a match are considered spectators and their involvement would be considered outside assistance.
-
-- All players must remain in their seats during the game. If a pause is needed, call a Judge.
-
-When discussing cards at the table:
-
-- Players are not required to disclose hidden information, although they may do so if they desire, as long as they follow the rules defined in the MAMTR - 3.13 Hidden Information
-- Judges will not enforce contracts or promises.
-- When resolving cards like Intuition, Thoughtseize, or similar, a player may choose to solicit advice from their opponents. Be wary. Your opponents do not have your best interests at heart.
-- Be sure to ask for advice before making your decision. Judges will not allow take backs after  strategic information has been gained.
-
 ## Recording and Image Capture
 
 At cEDH UK events photography and video recording may take place for the purposes of promotion or gameplay capture. If you would like to be excluded from this please notify the TO prior to the event.
+
+## Changelog
+
+### 2025-04-16
+
+- Lots of reorganising of the doc compared to the original word doc to group things together more logically and try to keep things related to the different MTR sections together.
+- Updated match structure to specify a match is first to one game win, to allow game draws in both swiss and single elimination portions of an event.
+- Updated End-of-Match procedure to specify the time limit for the final players turn and add an option for TOs to use turns if they wish.
+- Updated Conceding games or matches to specify that when a player concedes at any time other than on their turn that the judge will only ensure detrimental triggers are properly handled, all other triggers will be missed and the player will declare no blockers should they concede during combat.
+- Clarified Hidden Information being sharable if a player is accidentally showing cards in their hand, such as to the player sat next to them. This is inline with the official MTR but added this to ensure it's covered here too. Removed the section on sharing hidden information willingly with one or more players as this is now part of the official MTR.
+- Updated Player Communication to clarify that it applies for excessively trying to influence an action a player is trying to take and not for talking too much while holding priority, which should be handled as Slow Play or Stalling.
+- Removed the section on Reversing Decisions. The official MTR already covers things well enough in this area.
+- Removed the section allowing non-deterministic loops. Many scenarios encountered in cEDH that look non-deterministic are actually deterministic so this exception isn't actually needed.
+- Added a table showing recommended number of byes to offer based on event size. Feedback on these numbers is greatly appreciated, both in terms of how the standings ended up and in terms of how they byes vs 3 player pods felt for the players.
+- Added references to the end of match procedure for the swiss rounds along with standardising on 80 minute rounds.
+- Clarified single elimination time limits in the case of intentional draws.


### PR DESCRIPTION
Various changes to the MTR doc as it was getting pretty long and unwieldy:

- Merging over the combined doc that Arran had worked on using our addendum and the TopDeck addendum
- Removed duplicate sections from our MTR after merging in the above work
- Moved relevant sections to the IPG doc (in another PR)
- Used the Portugal MTR section on [Collusion, Coercion, and Spite Play](https://juizes-mtg-portugal.github.io/multiplayer-addendum-mtr#54-unsporting-conduct) as it's more thorough with it's examples.

The notable thing we're now missing is a section on Kingmaking but I think the problematic situations where that occurs are covered by the Spite Play rules, other times there is Kingmaking are usually due to accidental misplays and we can't really do much about those.